### PR TITLE
Hand now points to average depth of neighourhood of point

### DIFF
--- a/modules/handPointing/handPointingThread.h
+++ b/modules/handPointing/handPointingThread.h
@@ -115,6 +115,7 @@ public:
 
 private:
     yarp::sig::Vector& reachablePoint(const yarp::sig::Vector& v0 , const yarp::sig::Vector& v1 , const yarp::sig::Vector& vSC, yarp::sig::Vector& vreach );
+    double average_depth(int u,int v,int offset);
 };
 
 #endif


### PR DESCRIPTION
Modified:
- Depth of center is now computed as the average over a neighborhood (excluding outliers, where depth=0).